### PR TITLE
Unit prefix spelling in RNA plot

### DIFF
--- a/docs/templates/rna-in-rioolwater.template.html
+++ b/docs/templates/rna-in-rioolwater.template.html
@@ -45,7 +45,7 @@
             </p>
             <p>
                 De y-as van de grafiek gaat over het aantal virusdeeltjes per 100.000 inwoners. Dat kunnen er al snel
-                erg veel zijn, daarom bevat de y-as de letter 'T' van "Terra". Terra betekent 10<sup>12</sup>, ofwel een
+                erg veel zijn, daarom bevat de y-as de letter 'T' van "Tera". Tera betekent 10<sup>12</sup>, ofwel een
                 getal met 12 nullen. Op ${rna_per_100k_datum} werden er ${rna_per_100k} virusdeeltjes per 100.000
                 inwoners gemeten.
             </p>

--- a/scripts/createRNAGraph.py
+++ b/scripts/createRNAGraph.py
@@ -95,7 +95,7 @@ def createRNAGraph(metenisweten):
     ax1.set_yticklabels(['0',   '50T', '100T',  '150T', '200T',   '250T'])
 
     plt.figtext(0.10,0.72, 
-            "(T = Terra = 1.000.000.000.000)",
+            "(T = Tera = 1.000.000.000.000)",
             color="gray",
             fontsize = 8,
             bbox=dict(facecolor='white', alpha=1.0, 


### PR DESCRIPTION
Hi Rolf,

Saw that the unit prefix you are using for the RNA plot had an extra `r` in there. Thought this might help :)

Cheers,

Marcel